### PR TITLE
rewrite for Content::fillParserOutput deprecation (MW 1.38)

### DIFF
--- a/includes/Content.php
+++ b/includes/Content.php
@@ -8,39 +8,5 @@ class Content extends \TextContent {
 	public function __construct( $text, $model_id = self::MODEL ) {
 		parent::__construct( $text, $model_id );
 	}
-
-	public function getExtensionMap() {
-		// Turn e.g, [ 'foo', 'bar' => 'foo' ] to [ 'foo' => 'foo', 'bar' => 'foo' ]
-		//
-		// Need to do this transform as relying on keys instead (e.g. checking
-		// isset(wgSyntaxHighlightPagesSuffixes[$ext])) gives a surprising
-		// positive for e.g. 'Foo.0' because PHP casts the '0' to 0, which is a
-		// valid key if there are any non-mappped values.
-		//
-		// Also prevents [ 'foo' => 'bar' ] from enabling 'bar' as an extension
-		// which may not be desired.
-		global $wgSyntaxHighlightPagesSuffixes;
-		$map = array();
-		foreach ($wgSyntaxHighlightPagesSuffixes as $k => $v) {
-			$map[gettype($k) === "integer" ? $v : $k] = $v;
-		}
-		return $map;
-	}
-
-	protected function fillParserOutput(
-		\Title $title, $revId, \ParserOptions $options, $generateHtml, \ParserOutput &$output
-	){
-		$parts = explode('.', $title->getDBkey());
-		$ext = end($parts);
-		$map = Content::getExtensionMap();
-		$lang = isset($map[$ext]) ? $map[$ext] : "";
-		$status = \SyntaxHighlight::highlight( $this->mText, $lang );
-		if ( !$status->isOK() ) {
-			return true;
-		}
-
-		$output->addModuleStyles( 'ext.pygments' );
-		$output->setText( '<div dir="ltr">' . $status->getValue() . '</div>' );
-	}
 }
 

--- a/includes/ContentHandler.php
+++ b/includes/ContentHandler.php
@@ -7,7 +7,41 @@ class ContentHandler extends \TextContentHandler {
 		parent::__construct( $modelId, [ CONTENT_FORMAT_TEXT ] );
 	}
 
+	public static function getExtensionMap() {
+		// Turn e.g, [ 'foo', 'bar' => 'foo' ] to [ 'foo' => 'foo', 'bar' => 'foo' ]
+		//
+		// Need to do this transform as relying on keys instead (e.g. checking
+		// isset(wgSyntaxHighlightPagesSuffixes[$ext])) gives a surprising
+		// positive for e.g. 'Foo.0' because PHP casts the '0' to 0, which is a
+		// valid key if there are any non-mappped values.
+		//
+		// Also prevents [ 'foo' => 'bar' ] from enabling 'bar' as an extension
+		// which may not be desired.
+		global $wgSyntaxHighlightPagesSuffixes;
+		$map = array();
+		foreach ($wgSyntaxHighlightPagesSuffixes as $k => $v) {
+			$map[gettype($k) === "integer" ? $v : $k] = $v;
+		}
+		return $map;
+	}
+
 	protected function getContentClass() {
 		return Content::class;
+	}
+
+	protected function fillParserOutput(
+		\Content $content, \MediaWiki\Content\Renderer\ContentParseParams $cpoParams, \ParserOutput &$output
+	){
+		$title = $cpoParams->getPage()->getDBkey();
+		$parts = explode('.', $title);
+		$ext = end($parts);
+		$map = ContentHandler::getExtensionMap();
+		$lang = isset($map[$ext]) ? $map[$ext] : "";
+		$status = \MediaWiki\SyntaxHighlight\SyntaxHighlight::highlight( $content->getText(), $lang );
+		if ( !$status->isOK() ) {
+			return true;
+		}
+		$output->addModuleStyles([ 'ext.pygments' ]);
+		$output->setText( '<div dir="ltr">' . $status->getValue() . '</div>' );
 	}
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -5,7 +5,7 @@ class Hooks {
 	public static function onContentHandlerDefaultModelFor( \Title $title, &$model ) {
 		$parts = explode('.', $title->getDBkey());
 		$ext = end($parts);
-		$map = Content::getExtensionMap();
+		$map = ContentHandler::getExtensionMap();
 		if ($title->isContentPage() && isset($map[$ext])) {
 			$model = Content::MODEL;
 			return false;


### PR DESCRIPTION
Content::fillParserOutput() moved to ContentHandler::fillParserOutput(), which has different params, as the former is deprecated